### PR TITLE
feat: vrcft module tracking mode support

### DIFF
--- a/FoxyFace/src/config/schemas/core/SocketConfig.py
+++ b/FoxyFace/src/config/schemas/core/SocketConfig.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from src.config.schemas.core.enums.TrackingModeEnum import TrackingModeEnum
+
 
 @dataclass(slots=True)
 class SocketConfig:
@@ -8,3 +10,4 @@ class SocketConfig:
     auto_connect: bool = True
     udp_read_timeout: int = 2_500
     bypass_other_modules_block: bool = False
+    tracking_mode: TrackingModeEnum = TrackingModeEnum.BOTH

--- a/FoxyFace/src/config/schemas/core/enums/TrackingModeEnum.py
+++ b/FoxyFace/src/config/schemas/core/enums/TrackingModeEnum.py
@@ -1,0 +1,8 @@
+from enum import StrEnum, unique
+
+
+@unique
+class TrackingModeEnum(StrEnum):
+    MOUTH = "mouth"
+    EYES = "eyes"
+    BOTH = "both"

--- a/FoxyFace/src/pipline/UdpPipeline.py
+++ b/FoxyFace/src/pipline/UdpPipeline.py
@@ -48,13 +48,15 @@ class UdpPipeline:
         watch_array: list[Callable[[Config], Any]] = [lambda config: config.socket.ip,
                                                       lambda config: config.socket.port,
                                                       lambda config: config.socket.udp_read_timeout,
-                                                      lambda config: config.socket.bypass_other_modules_block]
+                                                      lambda config: config.socket.bypass_other_modules_block,
+                                                      lambda config: config.socket.tracking_mode]
 
         return self.__config_manager.create_update_listener(self.__update_options, watch_array, True)
 
     def __update_options(self, config_manager: ConfigManager):
         self.__options.udp_read_timeout_ms = config_manager.config.socket.udp_read_timeout
         self.__options.bypass_other_modules_block = config_manager.config.socket.bypass_other_modules_block
+        self.__options.tracking_mode = config_manager.config.socket.tracking_mode
 
         self.__stream.ping_connection_time = config_manager.config.socket.udp_read_timeout / 4000.0
         self.__stream.target_address = (config_manager.config.socket.ip, config_manager.config.socket.port)

--- a/FoxyFace/src/stream/vrcft/VrcftInterfaceOptions.py
+++ b/FoxyFace/src/stream/vrcft/VrcftInterfaceOptions.py
@@ -1,11 +1,15 @@
 from dataclasses import dataclass
 
+from src.config.schemas.core.enums.TrackingModeEnum import TrackingModeEnum
+
 
 @dataclass(slots=True)
 class VrcftInterfaceOptions:
     udp_read_timeout_ms: int = 5_000
     bypass_other_modules_block: bool = False
+    tracking_mode: TrackingModeEnum = TrackingModeEnum.BOTH
 
-    def to_packet_format_dict(self) -> dict[str, int | bool]:
+    def to_packet_format_dict(self) -> dict[str, int | bool | str]:
         return {"UdpReadTimeoutMs": self.udp_read_timeout_ms,
-                "BypassOtherModulesBlock": self.bypass_other_modules_block}
+                "BypassOtherModulesBlock": self.bypass_other_modules_block,
+                "TrackingMode": self.tracking_mode.value}

--- a/FoxyFace/src/stream/vrcft/VrcftPacketEncoderStream.py
+++ b/FoxyFace/src/stream/vrcft/VrcftPacketEncoderStream.py
@@ -37,7 +37,7 @@ class VrcftPacketEncoderStream(StreamReadOnly[bytes]):
 
         return self.__encode_object_to_json(
             {"Timestamp": packet_timestamp, "Config": self.__options.to_packet_format_dict(),
-             "Values": self.__mediapipe_to_vrcft_name(timed_blend_shapes.blend_shapes)})
+             "Values": self.__mediapipe_to_vrcft_name(timed_blend_shapes.blend_shapes, self.__options.tracking_mode)})
 
     def generate_ping_packet(self) -> bytes:
         return self.__encode_object_to_json({"PingPacket": True, "Config": self.__options.to_packet_format_dict()})
@@ -47,7 +47,7 @@ class VrcftPacketEncoderStream(StreamReadOnly[bytes]):
         return json.dumps(any_object, allow_nan=False, separators=(",", ":")).encode("utf-8")
 
     @staticmethod
-    def __mediapipe_to_vrcft_name(media_pipe_dict: dict[GeneralBlendShapeEnum, float]) -> dict[
+    def __mediapipe_to_vrcft_name(media_pipe_dict: dict[GeneralBlendShapeEnum, float], tracking_mode) -> dict[
         UnifiedExpressionEnum, float]:
         eye_close_left = media_pipe_dict.get(GeneralBlendShapeEnum.EyeBlinkLeft)
         eye_open_left = 1 - eye_close_left if eye_close_left is not None else None
@@ -189,4 +189,46 @@ class VrcftPacketEncoderStream(StreamReadOnly[bytes]):
                     }
         # @formatter:on
 
-        return {key: val for key, val in new_dict.items() if val is not None}
+        filtered_dict = {key: val for key, val in new_dict.items() if val is not None}
+
+        if tracking_mode == "mouth":
+            # Include only mouth-related expressions
+            mouth_keys = {
+                UnifiedExpressionEnum.JawForward, UnifiedExpressionEnum.JawLeft, UnifiedExpressionEnum.JawOpen,
+                UnifiedExpressionEnum.JawRight, UnifiedExpressionEnum.MouthClosed, UnifiedExpressionEnum.MouthDimpleLeft,
+                UnifiedExpressionEnum.MouthDimpleRight, UnifiedExpressionEnum.MouthFrownLeft, UnifiedExpressionEnum.MouthFrownRight,
+                UnifiedExpressionEnum.LipFunnelUpperRight, UnifiedExpressionEnum.LipFunnelUpperLeft, UnifiedExpressionEnum.LipFunnelLowerRight,
+                UnifiedExpressionEnum.LipFunnelLowerLeft, UnifiedExpressionEnum.MouthUpperLeft, UnifiedExpressionEnum.MouthLowerLeft,
+                UnifiedExpressionEnum.MouthLowerDownLeft, UnifiedExpressionEnum.MouthLowerDownRight, UnifiedExpressionEnum.MouthPressLeft,
+                UnifiedExpressionEnum.MouthPressRight, UnifiedExpressionEnum.LipPuckerUpperRight, UnifiedExpressionEnum.LipPuckerUpperLeft,
+                UnifiedExpressionEnum.LipPuckerLowerRight, UnifiedExpressionEnum.LipPuckerLowerLeft, UnifiedExpressionEnum.MouthUpperRight,
+                UnifiedExpressionEnum.MouthLowerRight, UnifiedExpressionEnum.LipSuckLowerRight, UnifiedExpressionEnum.LipSuckLowerLeft,
+                UnifiedExpressionEnum.LipSuckUpperRight, UnifiedExpressionEnum.LipSuckUpperLeft, UnifiedExpressionEnum.MouthRaiserLower,
+                UnifiedExpressionEnum.MouthRaiserUpper, UnifiedExpressionEnum.MouthCornerPullLeft, UnifiedExpressionEnum.MouthCornerSlantLeft,
+                UnifiedExpressionEnum.MouthCornerPullRight, UnifiedExpressionEnum.MouthCornerSlantRight, UnifiedExpressionEnum.MouthStretchLeft,
+                UnifiedExpressionEnum.MouthStretchRight, UnifiedExpressionEnum.MouthUpperUpLeft, UnifiedExpressionEnum.MouthUpperUpRight,
+                UnifiedExpressionEnum.NoseSneerLeft, UnifiedExpressionEnum.NoseSneerRight, UnifiedExpressionEnum.CheekPuffLeft,
+                UnifiedExpressionEnum.CheekPuffRight, UnifiedExpressionEnum.CheekSquintLeft, UnifiedExpressionEnum.CheekSquintRight,
+                UnifiedExpressionEnum.CheekSuckLeft, UnifiedExpressionEnum.CheekSuckRight, UnifiedExpressionEnum.TongueOut,
+                UnifiedExpressionEnum.TongueUp, UnifiedExpressionEnum.TongueDown, UnifiedExpressionEnum.TongueLeft,
+                UnifiedExpressionEnum.TongueRight, UnifiedExpressionEnum.TongueRoll, UnifiedExpressionEnum.TongueBendDown,
+                UnifiedExpressionEnum.TongueCurlUp, UnifiedExpressionEnum.TongueSquish, UnifiedExpressionEnum.TongueFlat,
+                UnifiedExpressionEnum.TongueTwistLeft, UnifiedExpressionEnum.TongueTwistRight
+            }
+            filtered_dict = {k: v for k, v in filtered_dict.items() if k in mouth_keys}
+        elif tracking_mode == "eyes":
+            # Include only eye and eyebrow related expressions
+            eye_keys = {
+                UnifiedExpressionEnum.BrowLowererLeft, UnifiedExpressionEnum.BrowPinchLeft, UnifiedExpressionEnum.BrowLowererRight,
+                UnifiedExpressionEnum.BrowPinchRight, UnifiedExpressionEnum.BrowInnerUpRight, UnifiedExpressionEnum.BrowInnerUpLeft,
+                UnifiedExpressionEnum.BrowOuterUpLeft, UnifiedExpressionEnum.BrowOuterUpRight, UnifiedExpressionEnum.EyeOpennessLeft,
+                UnifiedExpressionEnum.EyeOpennessRight, UnifiedExpressionEnum.EyeXLeft, UnifiedExpressionEnum.EyeXRight,
+                UnifiedExpressionEnum.EyeYLeft, UnifiedExpressionEnum.EyeYRight, UnifiedExpressionEnum.EyeSquintLeft,
+                UnifiedExpressionEnum.EyeSquintRight, UnifiedExpressionEnum.EyeWideLeft, UnifiedExpressionEnum.EyeWideRight,
+                UnifiedExpressionEnum.HeadX, UnifiedExpressionEnum.HeadY, UnifiedExpressionEnum.HeadZ,
+                UnifiedExpressionEnum.HeadPitch, UnifiedExpressionEnum.HeadYaw, UnifiedExpressionEnum.HeadRoll
+            }
+            filtered_dict = {k: v for k, v in filtered_dict.items() if k in eye_keys}
+        # For "both", include all
+
+        return filtered_dict

--- a/FoxyFace/src/ui/windows/VrcftSettingsWindow.py
+++ b/FoxyFace/src/ui/windows/VrcftSettingsWindow.py
@@ -9,6 +9,7 @@ from src.autorun.SteamAutoRun import SteamAutoRun
 from src.config.ConfigManager import ConfigManager
 from src.config.ConfigUpdateListener import ConfigUpdateListener
 from src.config.schemas.Config import Config
+from src.config.schemas.core.enums.TrackingModeEnum import TrackingModeEnum
 from src.ui.FoxyWindow import FoxyWindow
 from src.ui.qtcreator.ui_VrcftSettings import Ui_VrcftSettings
 
@@ -26,6 +27,16 @@ class VrcftSettingsWindow(FoxyWindow):
 
         self.__ui = Ui_VrcftSettings()
         self.__ui.setupUi(self)
+
+        # Add tracking mode combo box
+        from PySide6.QtWidgets import QLabel
+        self.__tracking_mode_lb = QLabel("Tracking Mode")
+        self.__ui.verticalLayout_7.addWidget(self.__tracking_mode_lb)
+        self.__tracking_mode_cb = QComboBox()
+        self.__tracking_mode_cb.addItem("Both", "both")
+        self.__tracking_mode_cb.addItem("Mouth Only", "mouth")
+        self.__tracking_mode_cb.addItem("Eyes Only", "eyes")
+        self.__ui.verticalLayout_7.addWidget(self.__tracking_mode_cb)
 
         self.__update_ip_signal.connect(self.__update_ip)
         self.__ui.save_btn.clicked.connect(self.__save)
@@ -73,6 +84,12 @@ class VrcftSettingsWindow(FoxyWindow):
         self.__ui.read_timeout_sp.setValue(self.__config_manager.config.socket.udp_read_timeout)
         self.__ui.bypass_cb.setChecked(self.__config_manager.config.socket.bypass_other_modules_block)
 
+        # Set tracking mode
+        tracking_mode = self.__config_manager.config.socket.tracking_mode.value
+        index = self.__tracking_mode_cb.findData(tracking_mode)
+        if index >= 0:
+            self.__tracking_mode_cb.setCurrentIndex(index)
+
         self.__ui.vrchat_file_path_le.setText(self.__config_manager.config.auto_run.vrchat_path)
         self.__ui.vrcft_file_path_le.setText(self.__config_manager.config.auto_run.vrcft_path)
 
@@ -92,6 +109,7 @@ class VrcftSettingsWindow(FoxyWindow):
             self.__config_manager.config.socket.port = self.__ui.port_sp.value()
             self.__config_manager.config.socket.udp_read_timeout = self.__ui.read_timeout_sp.value()
             self.__config_manager.config.socket.bypass_other_modules_block = self.__ui.bypass_cb.isChecked()
+            self.__config_manager.config.socket.tracking_mode = TrackingModeEnum(self.__tracking_mode_cb.currentData())
 
             self.__config_manager.config.auto_run.vrchat_path = self.__ui.vrchat_file_path_le.text()
             self.__config_manager.config.auto_run.vrcft_path = self.__ui.vrcft_file_path_le.text()

--- a/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/Core/FoxyFace/FoxyFaceDto.cs
+++ b/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/Core/FoxyFace/FoxyFaceDto.cs
@@ -11,5 +11,6 @@ public class FoxyFaceDto
     {
         public ushort UdpReadTimeoutMs { get; init; } = 5_000;
         public bool BypassOtherModulesBlock { get; init; } = false;
+        public string TrackingMode { get; init; } = "both";
     }
 }

--- a/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/Core/FoxyFace/FoxyFacePacketProcessor.cs
+++ b/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/Core/FoxyFace/FoxyFacePacketProcessor.cs
@@ -29,15 +29,33 @@ public class FoxyFacePacketProcessor
         GenerateUnifiedExpressionsDictionary();
 
     private readonly bool _headRotationAllowed = UnifiedTracking.Data.GetType().GetField("Head") != null;
+    
+    private string _trackingMode = "both";
 
     public FoxyFacePacketProcessor(ILogger logger)
     {
         logger.LogInformation("Available {} unified expressions. Head Position/Rotation Allowed: {}",
             _unifiedExpressionsDictionary.Count, _headRotationAllowed);
     }
+    
+    public void SetTrackingMode(string trackingMode)
+    {
+        _trackingMode = trackingMode?.ToLower() ?? "both";
+    }
 
     public void UpdateEyes(Dictionary<string, float> foxyFaceValues)
     {
+        if (_trackingMode == "mouth")
+        {
+            UnifiedTracking.Data.Eye.Right.Gaze.x = 0;
+            UnifiedTracking.Data.Eye.Right.Gaze.y = 0;
+            UnifiedTracking.Data.Eye.Right.Openness = 0;
+            UnifiedTracking.Data.Eye.Left.Gaze.x = 0;
+            UnifiedTracking.Data.Eye.Left.Gaze.y = 0;
+            UnifiedTracking.Data.Eye.Left.Openness = 0;
+            return;
+        }
+        
         if (foxyFaceValues.TryGetValue(EyeRightX, out float eyeRightXValue))
         {
             UnifiedTracking.Data.Eye.Right.Gaze.x = eyeRightXValue;
@@ -81,6 +99,9 @@ public class FoxyFacePacketProcessor
 
     public void UpdateExpression(Dictionary<string, float> foxyFaceValues)
     {
+        // Skip expression updates if tracking mode is "eyes"
+        if (_trackingMode == "eyes") return;
+        
         foreach (KeyValuePair<string, float> pair in foxyFaceValues)
         {
             if (_unifiedExpressionsDictionary.TryGetValue(pair.Key, out int shapeKey))

--- a/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface.cs
+++ b/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface/FoxyFaceVRCFTInterface.cs
@@ -29,8 +29,15 @@ public class FoxyFaceVRCFTInterface : ExtTrackingModule
 
     private FoxyFaceUdpClient _udpClient = null!;
     private FoxyFacePacketProcessor _packetProcessor = null!;
+    private string _trackingMode = "both";
 
-    public override (bool SupportsEye, bool SupportsExpression) Supported => (true, true);
+    public override (bool SupportsEye, bool SupportsExpression) Supported => 
+        _trackingMode switch
+        {
+            "mouth" => (false, true),
+            "eyes" => (true, false),
+            _ => (true, true)
+        };
 
     public override (bool eyeSuccess, bool expressionSuccess) Initialize(bool eyeAvailable, bool expressionAvailable)
     {
@@ -99,10 +106,16 @@ public class FoxyFaceVRCFTInterface : ExtTrackingModule
         }
 
         _packetProcessor = new FoxyFacePacketProcessor(FoxyFaceSpamLogger);
+        _trackingMode = packetConfig.TrackingMode?.ToLower() ?? "both";
 
-        FoxyFaceLogger.LogInformation("FoxyFace app is connected successfully!");
+        FoxyFaceLogger.LogInformation("FoxyFace app is connected successfully! Tracking mode: {}", _trackingMode);
 
-        return (eyeAvailable, expressionAvailable);
+        return _trackingMode switch
+        {
+            "mouth" => (false, expressionAvailable),
+            "eyes" => (eyeAvailable, false),
+            _ => (eyeAvailable, expressionAvailable)
+        };
     }
 
     public override void Update()
@@ -119,6 +132,13 @@ public class FoxyFaceVRCFTInterface : ExtTrackingModule
             FoxyFaceDto? packet = _udpClient.TryRequest();
 
             if (packet?.Values == null || packet.Values.Count == 0) return;
+            
+            if (packet.Config != null && packet.Config.TrackingMode != _trackingMode)
+            {
+                _trackingMode = packet.Config.TrackingMode?.ToLower() ?? "both";
+                _packetProcessor.SetTrackingMode(_trackingMode);
+                FoxyFaceLogger.LogInformation("Tracking mode changed to: {}", _trackingMode);
+            }
             
             _packetProcessor.UpdateEyes(packet.Values);
             _packetProcessor.UpdateExpression(packet.Values);


### PR DESCRIPTION
# Add VRCFT module tracking mode support

For me, this is useful because I can get better face tracking in the headset by using Foxy Face "mediapipe" for mouth tracking and Project-Babble/Baballonia app for eye tracking.

## Summary
Implements tracking mode support in the FoxyFaceVRCFTInterface module, allowing users to selectively enable eye tracking, mouth/expression tracking, or both. The module now dynamically reports its capabilities to VRCFT based on the selected tracking mode.

## Changes
- **Added `TrackingModeEnum`**: New enum in Python code defining three tracking modes: `mouth`, `eyes`, and `both`
- **Dynamic module reporting**: The VRCFT module now reports supported tracking types based on the active tracking mode

## Behavior
- **Mouth mode**: Only expression/face tracking is active, eye tracking is disabled and reset
- **Eyes mode**: Only eye tracking is active, expression tracking is disabled
- **Both mode** (default): Both eye and expression tracking are active

