### PR TITLE
fix(onnx): preload CUDA runtime libraries

### DIFF
--- a/FoxyFace/src/util/OnnxUtil.py
+++ b/FoxyFace/src/util/OnnxUtil.py
@@ -11,6 +11,10 @@ except ImportError:
 
 import onnxruntime
 
+if hasattr(onnxruntime, "preload_dlls"):
+    onnxruntime.preload_dlls()
+
+
 onnxruntime.disable_telemetry_events()
 
 _DEVICE_ID_KEY = "device_id"


### PR DESCRIPTION
When installing onnxruntime-gpu via pip, it puts cuda/cudnn libs into python package directories, which are not always searched by the system dynamic loader which may make it look to python like cuda is not available

adding this preload_dlls call is the official way of locating/loading cuda/cudnn libs supplied by pytorch or pip packages, see :
https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#preload-dlls

also, a check makes it so it won't run for versions of onnxruntime that don't support this (<1.21.0)